### PR TITLE
Fix terriajs package.json url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-dependencies",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Updates dependency versions in one package.json to match another.",
   "repository": {
     "type": "git",

--- a/sync-dependencies.js
+++ b/sync-dependencies.js
@@ -69,7 +69,7 @@ if (argv.from) {
         ], { shell: true });
         sourcePackageJsonPromise = Promise.resolve(JSON.parse(npmViewResult.stdout.toString()));
     } else if (resolvedPackage.type === 'git' && resolvedPackage.hosted) {
-        const packageJsonUrl = resolvedPackage.hosted.file('package.json');
+        const packageJsonUrl = resolvedPackage.hosted.file('package.json', {noCommittish: false});
         console.log('Syncing from ' + packageJsonUrl);
         sourcePackageJsonPromise = new Promise((resolve, reject) => {
             request(packageJsonUrl, (error, response, body) => {


### PR DESCRIPTION
CI deployments are broken after a recent release of [hosted-git-info](https://github.com/npm/hosted-git-info/). This change fixes it.